### PR TITLE
Fix template path

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -24,7 +24,7 @@
     "fileMetadataFiles": [],
     "template": [
       "default",
-      "../darkFX"
+      "../darkfx"
     ],
     "postProcessors": [
       "ExtractSearchIndex"


### PR DESCRIPTION
The previous way worked as long as you use a case-sensitive file system, but since I run `docfx` on Linux this is not the case for me. Without this change, the `docfx` theme would not be applied at all (the site would be generated using the default `docfx` theme only). I happened to notice this when I was working on another theme based on `darkfx` (will post the link once it's ready. :smile:)

(Side note: I _strongly_ suggest all developers reading this to consider using a case-sensitive file system, to avoid bugs like this.It's basically impossible to never make these kind of mistakes if you are using a case-insensitive file system - like the default Windows or macOS file systems)

I realize this might not be easy if Windows or macOS is your main development platform, but one convenient way to workaround this is to at least run CI (continuous integration) for your project on an OS with a case-sensitive file system (like Linux). Here's some inspiration in case anyone is interested:

- https://github.com/perlang-org/perlang/blob/master/.github/workflows/publish-website.yml#L19-L20: my GitHub Actions Workflow for building a `docfx`-based web site on each commit to `master`
- https://github.com/perlang-org/perlang/blob/master/Makefile#L28-L29: the `Makefile` used by the above
